### PR TITLE
changed the way urls show up on the template

### DIFF
--- a/core/templates/index.html
+++ b/core/templates/index.html
@@ -11,7 +11,7 @@
                 <li class="b--solid ma1 bg-light-yellow list justify-between">
                     <div class="w-100">
                     <a class=" ml2 w-30 f3 black" href="{% url 'post_detail' slug=post.slug %}">{{ post.title }}</a>
-                    <a class="w-two-thirds dim blue" target="_blank" href="{{ post.post_url }}">{{ post.post_url }}</a>
+                    {{ post.post_url|urlizetrunc:20 }}
                     </div>
                     <div class="flex ml2">
                     <p class="ml2 w-100">{{ post.description }}</p>


### PR DESCRIPTION
On the index.html template I changed the url for the linked article. Even though I changed the model to be a URLField, if for some reason we change it back to a CharField, the user can enter google.com and it will go to that page instead of ourwebsite/core/google.com and bring up an error.

@ChristianLMedlin 